### PR TITLE
Add Posthog integration to goodbye page

### DIFF
--- a/env.d.ts
+++ b/env.d.ts
@@ -1,3 +1,4 @@
 interface Window {
-    twttr: any
-  }
+  twttr: any;
+  posthog: any;
+}

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -45,5 +45,17 @@ module.exports = {
         pixelId: "o9kgt",
       },
     },
+    {
+      resolve: `gatsby-plugin-posthog`,
+      options: {
+        apiKey: "phc_VzveyNxrn2xyiKDYn7XjrgaqELGeUilDZGiBVh6jNmh",
+        initOptions: {
+          persistence: "localStorage",
+          autocapture: false,
+          capture_pageview: false,
+          disable_session_recording: true,
+        },
+      },
+    },
   ],
 };

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "1.0.0",
   "private": true,
   "description": "taho.xyz",
-  "author": "Taho <doggos@tallyho.org>",
-  "repository": "git@github.com:thesis/tallyho.org.git",
+  "author": "Taho <doggos@taho.xyz>",
+  "repository": "git@github.com:tahowallet/taho.xyz",
   "license": "MIT",
   "keywords": [
     "ethereum",
@@ -43,6 +43,7 @@
     "gatsby-plugin-matomo": "^0.11.0",
     "gatsby-plugin-mdx": "2",
     "gatsby-plugin-offline": "^3.10.0",
+    "gatsby-plugin-posthog": "^1.0.1",
     "gatsby-plugin-react-helmet": "^3.10.0",
     "gatsby-plugin-sharp": "^2.14.1",
     "gatsby-plugin-twitter-pixel": "^2.0.2",

--- a/src/pages/goodbye.tsx
+++ b/src/pages/goodbye.tsx
@@ -1,14 +1,22 @@
 import { css } from "linaria";
-import React from "react";
-import { bodyLightGold5, bodyDarkHunterGreen, bodyDarkGreen40 } from "shared/styles/colors";
-import { segmentFontFamily, quincyRegularFontFamily } from "shared/styles/font-families";
+import React, { useEffect } from "react";
+import {
+  bodyLightGold5,
+  bodyDarkHunterGreen,
+  bodyDarkGreen40,
+} from "shared/styles/colors";
+import {
+  segmentFontFamily,
+  quincyRegularFontFamily,
+} from "shared/styles/font-families";
 
 css`
-   :global() {
+  :global() {
     .container {
       height: 100vh;
       scroll-behavior: smooth;
-      background: ${bodyDarkHunterGreen} url("../shared/images/bg-dark.png") no-repeat;
+      background: ${bodyDarkHunterGreen} url("../shared/images/bg-dark.png")
+        no-repeat;
       background-size: cover;
       background-position: center bottom;
       font-size: max(10px, min(1.25vw, 16px));
@@ -24,7 +32,7 @@ css`
       color: ${bodyLightGold5};
     }
     .banner h1 {
-      color: #E1953A;
+      color: #e1953a;
       font-family: ${quincyRegularFontFamily};
       font-size: 48px;
       font-weight: normal;
@@ -57,39 +65,54 @@ css`
   }
 `;
 
-const Goodbye = () => (
-  <div className="container">
-    <div className="banner">
-      <div className="branding"/>
-      <h1>We’re sorry to see you go 🙁</h1>
-      {/* Drop typeform code here */}
-      <p>It didn't work out this time, but you can still stay plugged in with our community!</p>
-      <p>Follow us for news on improvements and new features.</p><br/><br/>
-      <div className="social-container">
-        <SocialIcon
-          href="https://chat.tallyho.org"
-          icon={{
-            width: `24px`,
-            height: `24px`,
-            src: `url(${require("../features/Footer/Nav/social-icons/discord-light.svg")})`,
-            hoverSrc: `url(${require("../features/Footer/Nav/social-icons/discord-hover.svg")})`,
-            activeSrc: `url(${require("../features/Footer/Nav/social-icons/discord-click.svg")})`,
-          }}
-        />
-        <SocialIcon
-          href="https://twitter.com/TallyHoOfficial"
-          icon={{
-            width: `28px`,
-            height: `24px`,
-            src: `url(${require("../features/Footer/Nav/social-icons/twitter-light.svg")})`,
-            hoverSrc: `url(${require("../features/Footer/Nav/social-icons/twitter-hover.svg")})`,
-            activeSrc: `url(${require("../features/Footer/Nav/social-icons/twitter-click.svg")})`,
-          }}
-        />
+function Goodbye() {
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+
+    if (window.posthog !== undefined) {
+      window.posthog.capture("Uninstall", { distinct_id: params.get("uuid") });
+    }
+  }, []);
+
+  return (
+    <div className="container">
+      <div className="banner">
+        <div className="branding" />
+        <h1>We’re sorry to see you go 🙁</h1>
+        {/* Drop typeform code here */}
+        <p>
+          It didn't work out this time, but you can still stay plugged in with
+          our community!
+        </p>
+        <p>Follow us for news on improvements and new features.</p>
+        <br />
+        <br />
+        <div className="social-container">
+          <SocialIcon
+            href="https://chat.taho.xyz"
+            icon={{
+              width: `24px`,
+              height: `24px`,
+              src: `url(${require("../features/Footer/Nav/social-icons/discord-light.svg")})`,
+              hoverSrc: `url(${require("../features/Footer/Nav/social-icons/discord-hover.svg")})`,
+              activeSrc: `url(${require("../features/Footer/Nav/social-icons/discord-click.svg")})`,
+            }}
+          />
+          <SocialIcon
+            href="https://twitter.com/taho_xyz"
+            icon={{
+              width: `28px`,
+              height: `24px`,
+              src: `url(${require("../features/Footer/Nav/social-icons/twitter-light.svg")})`,
+              hoverSrc: `url(${require("../features/Footer/Nav/social-icons/twitter-hover.svg")})`,
+              activeSrc: `url(${require("../features/Footer/Nav/social-icons/twitter-click.svg")})`,
+            }}
+          />
+        </div>
       </div>
     </div>
-</div>
-);
+  );
+}
 
 function SocialIcon({
   href,

--- a/yarn.lock
+++ b/yarn.lock
@@ -9548,6 +9548,13 @@ gatsby-plugin-react-helmet@^3.10.0:
   dependencies:
     "@babel/runtime" "^7.12.5"
 
+gatsby-plugin-posthog@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-posthog/-/gatsby-plugin-posthog-1.0.1.tgz#e455720a66d235ed8d7f508e9e575f95e20f189b"
+  integrity sha512-RIyDTj/XcMvmV6Vs6HJa8zQFGcQr52LcS4iD76g5WfFB705hFOAPchIISFoFMQd3qN1n3m4jUinhA/uuhN43Qg==
+  dependencies:
+    "@babel/runtime" "^7.8.7"
+
 gatsby-plugin-sharp@^2.14.1:
   version "2.14.1"
   resolved "https://registry.npmjs.org/gatsby-plugin-sharp/-/gatsby-plugin-sharp-2.14.1.tgz"


### PR DESCRIPTION
Slip into `useEffect` so that it properly renders client-side instead of trying to run server-side where it won't work.

Uses gatsby-plugin-posthog and captures an event, `Uninstall`, based on a UUID passed as a querystring parameter to the page. The extension is expected to provide the correct value when uninstalling.

-----

Realized this probably didn't require the Gatsby bump, so let's not debug that right now.