### PR TITLE
Fix spacing for goodbye page

### DIFF
--- a/src/pages/goodbye.tsx
+++ b/src/pages/goodbye.tsx
@@ -66,6 +66,7 @@ css`
     .social-container {
       max-width: 200px;
       text-align: center;
+      padding-bottom: 32px;
     }
     .form {
       margin: 1rem 0 2rem;
@@ -93,7 +94,7 @@ function Goodbye() {
 
   useEffect(() => {
     if (containerRef.current) {
-      setMaxHeight(`${containerRef.current.scrollHeight}px`)
+      setMaxHeight(`${containerRef.current.scrollHeight + 0}px`)
     }
   }, [containerRef?.current?.scrollHeight])
 

--- a/src/pages/goodbye.tsx
+++ b/src/pages/goodbye.tsx
@@ -94,7 +94,7 @@ function Goodbye() {
 
   useEffect(() => {
     if (containerRef.current) {
-      setMaxHeight(`${containerRef.current.scrollHeight + 0}px`)
+      setMaxHeight(`${containerRef.current.scrollHeight}px`)
     }
   }, [containerRef?.current?.scrollHeight])
 


### PR DESCRIPTION
This PR adds `padding-bottom` for social icons on the goodbye page. In some cases, the bottom space for social icons is missing on small screens. 

### UI
Before
<img width="1252" alt="Screenshot 2023-04-10 at 13 51 16" src="https://user-images.githubusercontent.com/23117945/230896494-ea785584-d21f-4e5b-859b-506387c8010f.png">

After 
<img width="1254" alt="Screenshot 2023-04-10 at 13 53 40" src="https://user-images.githubusercontent.com/23117945/230896808-660258a2-3b66-4f21-81c2-6af0bcfe602f.png">

